### PR TITLE
Fix a bug in centrifuger-kreport 

### DIFF
--- a/centrifuger-kreport
+++ b/centrifuger-kreport
@@ -236,7 +236,7 @@ sub load_taxonomy {
   while (<NAMES>) {
     chomp;
     s/\t\|$//;
-    my @fields = split /\t/;
+    my @fields = split /\t\|\t/;
     my ($node_id, $name) = @fields[0,1];
     $name_map{$node_id} = $name;
   }

--- a/defs.h
+++ b/defs.h
@@ -5,7 +5,7 @@
 
 //#define DEBUG
 
-#define CENTRIFUGER_VERSION "1.0.6-r195"
+#define CENTRIFUGER_VERSION "1.0.7-r197"
 
 extern char nucToNum[26] ; 
 extern char numToNuc[26] ;


### PR DESCRIPTION
Fix a bug in centrifuger-kreport that uses a wrong column in the reformatted centrifuger-inspect name-table output (#28 )