### PR TITLE
Fix a serious issue for backcompatbility issue of taxonomy tree in the index

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Here is a list of pre-built indexes:
 |-------|------|------|
 | Refseq human, bacteria, archea, virus + SARS-CoV2-variants from GenBank | [Zenodo](https://zenodo.org/records/10023239) | 2023/10/1 |
 | [GTDB r226](https://gtdb.ecogenomic.org/) | [Dropbox](https://www.dropbox.com/scl/fo/xjp5r81jxkzxest9ijxul/ADfYFKoxIyl0hrICeEI63QM?rlkey=5lij0ocrbre165pa52mavux5z&st=4ol28yv2&dl=0) | 2025/05/20 |
-| GTDB r226 + Refseq human, virus, fungi, and contaminant (UniVec,EmVec)| [Dropbox](https://www.dropbox.com/scl/fo/tkoge61zh199i9n2l7891/AL_8z4zzTm0tHvHJh8UrIdg?rlkey=3abt78pbbtn9v5w2ulz0nfjw2&st=m1ir66th&dl=0) | 2025/05/20 |
 | NCBI nt | [Dropbox](https://www.dropbox.com/scl/fo/dbjzuerib7nfluj2u3yw7/AER-MP9RaqL0g59YwTXe4RU?rlkey=7zy78nvwdw19fuaetnn3u7qhi&st=6un1f4ux&dl=0)  | 2018 |
 
 #### Classification

--- a/Taxonomy.hpp
+++ b/Taxonomy.hpp
@@ -34,7 +34,6 @@ enum
     RANK_PHYLUM,
     RANK_KINGDOM,
     RANK_DOMAIN,
-    RANK_ACELLULAR_ROOT,
     RANK_FORMA,
     RANK_INFRA_CLASS,
     RANK_INFRA_ORDER,
@@ -55,6 +54,7 @@ enum
     RANK_TRIBE,
     RANK_VARIETAS,
     RANK_LIFE,
+    RANK_ACELLULAR_ROOT, // New taxonomy rank IDs should be added to the end of the list to make sure backward compatbility
     RANK_MAX
 };
 

--- a/defs.h
+++ b/defs.h
@@ -5,7 +5,7 @@
 
 //#define DEBUG
 
-#define CENTRIFUGER_VERSION "1.0.10-r249"
+#define CENTRIFUGER_VERSION "1.0.10-r251"
 
 #define SAMPLE_SHEET_SEPARATOR_READ_ID "__centrifuger_sample_sheet_separator__"
 

--- a/defs.h
+++ b/defs.h
@@ -5,7 +5,7 @@
 
 //#define DEBUG
 
-#define CENTRIFUGER_VERSION "1.0.10-r251"
+#define CENTRIFUGER_VERSION "1.0.10-r252"
 
 #define SAMPLE_SHEET_SEPARATOR_READ_ID "__centrifuger_sample_sheet_separator__"
 


### PR DESCRIPTION
- Temporarily remove the GTDBr226+Refseq database link in the README for now. Will recreate the index soon.