### PR TITLE
Fix an issue in centrifuger-kreport in parsing taxonomy tree format

### DIFF
--- a/centrifuger-kreport
+++ b/centrifuger-kreport
@@ -281,6 +281,7 @@ sub load_taxonomy {
     or die "$PROG: can't open nodes file: $!\n";
   while (<NODES>) {
     chomp;
+    s/\t\|$//;
     my @fields = split /\t\|\t/;
     my ($node_id, $parent_id, $rank) = @fields[0,1,2];
     if ($node_id == 1) {

--- a/defs.h
+++ b/defs.h
@@ -5,7 +5,7 @@
 
 //#define DEBUG
 
-#define CENTRIFUGER_VERSION "1.0.11-r259"
+#define CENTRIFUGER_VERSION "1.0.11-r260"
 
 #define SAMPLE_SHEET_SEPARATOR_READ_ID "__centrifuger_sample_sheet_separator__"
 


### PR DESCRIPTION
Otherwise, the taxonomy rank in the centrifuger-kreport output will be missing.