### PR TITLE
Fix an issue in centrifuger-download 

### DIFF
--- a/centrifuger-download
+++ b/centrifuger-download
@@ -74,8 +74,8 @@ function download_n_process() {
           rm $UNZIPPED_FILE
         fi
     fi
-
-    if [[ "$FILE_TAXID_MAP" == 0 ]]; then 
+   
+    if [[ "$FILE_TAXID_MAP" == "0" ]]; then 
       ## Output sequenceID to taxonomy ID map to STDOUT
       gzip -cd < $RES_FILE | map_headers_to_taxid $TAXID
     else
@@ -326,6 +326,7 @@ fi
 export LIBDIR="$BASE_DIR"
 export DO_DUST="$DO_DUST"
 export CHANGE_HEADER="$CHANGE_HEADER"
+export FILE_TAXID_MAP="$FILE_TAXID_MAP"
 
 #### Handle multithreading
 export LOCK_FILE=""

--- a/defs.h
+++ b/defs.h
@@ -5,7 +5,7 @@
 
 //#define DEBUG
 
-#define CENTRIFUGER_VERSION "1.0.11-r259"
+#define CENTRIFUGER_VERSION "1.0.11-r262"
 
 #define SAMPLE_SHEET_SEPARATOR_READ_ID "__centrifuger_sample_sheet_separator__"
 


### PR DESCRIPTION
Fix a bug of wrongly generating the file to taxID information instead of the seqID to taxID 