### PR TITLE
Fix a serious issue in initialize differen cover for centrifuger-build

### DIFF
--- a/Quantifier.hpp
+++ b/Quantifier.hpp
@@ -362,6 +362,8 @@ public:
     _readCount = NULL ;
     _uniqReadCount = NULL ;
     _taxidLength = NULL ;
+
+    _hasExpandedTaxIds = false ;
   }
 
   ~Quantifier()

--- a/compactds/DifferenceCover.hpp
+++ b/compactds/DifferenceCover.hpp
@@ -68,10 +68,10 @@ public:
   void Init(int v)
   {
     int i ;
-    if (_v <= 13)
-      _v = 14 ;
+    if (v <= 13)
+      v = 14 ;
 
-    this->_v = _v ;
+    this->_v = v ;
     // Use the Colbourn, Ling method to find the cover 
     int r = CEIL((-36 + sqrt(1296 - 96*(13 - v)))/48.0) ;
     SimpleVector<int> rawdcs ; 

--- a/defs.h
+++ b/defs.h
@@ -5,7 +5,7 @@
 
 //#define DEBUG
 
-#define CENTRIFUGER_VERSION "1.0.12-r273"
+#define CENTRIFUGER_VERSION "1.0.12-r282"
 
 #define SAMPLE_SHEET_SEPARATOR_READ_ID "__centrifuger_sample_sheet_separator__"
 


### PR DESCRIPTION
- It reads a wrong v value in a recent code refactoring.
- Also fixed a small initialization issue for quantifier.