### PR TITLE
Fix a serious bug in centrifuger-build 

### DIFF
--- a/Builder.hpp
+++ b/Builder.hpp
@@ -126,7 +126,7 @@ public:
           continue ;
       }
 
-      if (!conversionTableAtFileLevel && _seqLength.find(seqid) != _seqLength.end()) // Assume there is no duplicated seqid. Thought this happens a lot in the protein database...we handle that by promoting the seqid's corresponidng taxID to LCA, so we only need to store that sequence once.
+      if (!conversionTableAtFileLevel && _seqLength.find(seqid) != _seqLength.end()) // Assume there is no duplicated seqid. Though this happens a lot in the protein database...we handle that by promoting the seqid's corresponding taxID to LCA, so we only need to store that sequence once.
         continue ;
 
       if (seqid >= _taxonomy.GetSeqCount())
@@ -156,7 +156,7 @@ public:
           genomeSeqIds.push_back(seqid) ;
           genomeLens.push_back(len) ;
         }
-        else
+        else // This should only happen when conversionTableAtFileLevel is true, and seqid is esstentially filename, so genomeLens can be safely added together.
         {
           _seqLength[seqid] += len ;
           genomeLens[ genomeLens.size() - 1 ] += len ;

--- a/Builder.hpp
+++ b/Builder.hpp
@@ -126,7 +126,7 @@ public:
           continue ;
       }
 
-      if (_seqLength.find(seqid) != _seqLength.end()) // Assume there is no duplicated seqid. Thought this happens a lot in the protein database...we handle that by promoting the seqid's corresponidng taxID to LCA, so we only need to store that sequence once.
+      if (!conversionTableAtFileLevel && _seqLength.find(seqid) != _seqLength.end()) // Assume there is no duplicated seqid. Thought this happens a lot in the protein database...we handle that by promoting the seqid's corresponidng taxID to LCA, so we only need to store that sequence once.
         continue ;
 
       if (seqid >= _taxonomy.GetSeqCount())
@@ -150,9 +150,17 @@ public:
           continue ;
         }
 
-        _seqLength[seqid] = len ;
-        genomeSeqIds.push_back(seqid) ;
-        genomeLens.push_back(len) ;
+        if (_seqLength.find(seqid) == _seqLength.end() )
+        {
+          _seqLength[seqid] = len ;
+          genomeSeqIds.push_back(seqid) ;
+          genomeLens.push_back(len) ;
+        }
+        else
+        {
+          _seqLength[seqid] += len ;
+          genomeLens[ genomeLens.size() - 1 ] += len ;
+        }
       }
       else // concatenate seuqences with the same tax ID
       {

--- a/defs.h
+++ b/defs.h
@@ -5,7 +5,7 @@
 
 //#define DEBUG
 
-#define CENTRIFUGER_VERSION "1.1.2-r310"
+#define CENTRIFUGER_VERSION "1.1.2-r312"
 
 #define SAMPLE_SHEET_SEPARATOR_READ_ID "__centrifuger_sample_sheet_separator__"
 


### PR DESCRIPTION
Fix a bug of only using the first sequence in a file when using the -l option for file to taxid conversion