### PR TITLE
More robust echo in flock

### DIFF
--- a/centrifuger-download
+++ b/centrifuger-download
@@ -29,18 +29,18 @@ export -f map_headers_to_taxid
 
 flock_echo_e() {
     if [[ $LOCK_FILE != "" ]]; then
-      flock -x $LOCK_FILE -c "echo -e $1"
+      flock -x $LOCK_FILE -c "echo -e \"$1\""
     else # this handles the single-thread case
-      echo -e $1
+      echo -e "$1"
     fi
 }
 export -f flock_echo_e
 
 flock_echo() {
     if [[ $LOCK_FILE != "" ]]; then
-      flock -x $LOCK_FILE -c "echo $1"
+      flock -x $LOCK_FILE -c "echo \"$1\""
     else # this handles the single-thread case
-      echo $1
+      echo "$1"
     fi
 }
 export -f flock_echo

--- a/defs.h
+++ b/defs.h
@@ -5,7 +5,7 @@
 
 //#define DEBUG
 
-#define CENTRIFUGER_VERSION "1.1.2-r320"
+#define CENTRIFUGER_VERSION "1.1.2-r322"
 
 #define SAMPLE_SHEET_SEPARATOR_READ_ID "__centrifuger_sample_sheet_separator__"
 


### PR DESCRIPTION
- This fixes a bug that cannot parse "\t" with the -f option in some shell versions.