### PR TITLE
Allow centrifuger-download to directly use the assembly_summary file

### DIFF
--- a/Taxonomy.hpp
+++ b/Taxonomy.hpp
@@ -63,11 +63,22 @@ struct TaxonomyNode
     uint64_t parentTid;
     uint8_t  rank;
     uint8_t  leaf;
+    uint8_t  padding[6] ; // for memory alignment, should be 6 bytes in total, considering rank and leaf
 
     TaxonomyNode(uint64_t _parent_tid, uint8_t  _rank, uint8_t _leaf):
-      parentTid(_parent_tid), rank(_rank), leaf(_leaf) {};
+      parentTid(_parent_tid), rank(_rank), leaf(_leaf) 
+    {
+      int i ;
+      for (i = 0 ; i < 6 ; ++i)
+        padding[i] = 0 ;
+    };
 
-    TaxonomyNode(): parentTid(0), rank(RANK_UNKNOWN), leaf(false) {};
+    TaxonomyNode(): parentTid(0), rank(RANK_UNKNOWN), leaf(false) 
+    {
+      int i ;
+      for (i = 0 ; i < 6 ; ++i)
+        padding[i] = 0 ;
+    }
 };
 
 

--- a/centrifuger-download
+++ b/centrifuger-download
@@ -499,7 +499,8 @@ for DOMAIN in $DOMAINS; do
       fi
     else
       echo "Using custom assembly_summary.txt file at $DATABASE" >&2
-      cp "$DATABASE" "$FULL_ASSEMBLY_SUMMARY_FILE"
+      [[ -s "$DATABASE" ]] || { echo "ERROR: custom assembly_summary file not found or empty: $DATABASE" >&2; exit 1; }
+      [[ "$DATABASE" -ef "$FULL_ASSEMBLY_SUMMARY_FILE" ]] || cp "$DATABASE" "$FULL_ASSEMBLY_SUMMARY_FILE"
     fi
 
     awk -F "\t" "BEGIN {OFS=\"\t\"} $AWK_QUERY" "$FULL_ASSEMBLY_SUMMARY_FILE" > "$ASSEMBLY_SUMMARY_FILE"

--- a/centrifuger-download
+++ b/centrifuger-download
@@ -195,6 +195,7 @@ ARGUMENT
                      - use refseq or genbank for genomic sequences,
                      - contaminants gets contaminant sequences from UniVec and EmVec,
                      - taxonomy for taxonomy mappings,
+                     - file name with extension \".txt\" for a custom assembly_summary.txt file, will override the domain option,
                      - pre-built indices with the prefix \"cfr\".
 
 COMMON OPTIONS
@@ -441,10 +442,12 @@ TAXID=${TAXID//,/|}
 #echo "$AWK_QUERY" >&2
 
 #echo "Downloading genomes for $DOMAINS at assembly level $ASSEMBLY_LEVEL" >&2
-if exists wget; then
+if [[ "$DATABASE" != *".txt" ]] ; then
+  if exists wget; then
     wget -qO- --no-remove-listing https://ftp.ncbi.nlm.nih.gov/genomes/$DATABASE/ > /dev/null
-else
+  else
     curl --disable-epsv -s https://ftp.ncbi.nlm.nih.gov/genomes/$DATABASE/ > .listing
+  fi
 fi
 
 if [[ "$CHANGE_HEADER" == "1" ]]; then
@@ -454,6 +457,10 @@ fi
 FILE_EXTENSION="genomic.fna.gz"
 if [[ "$DOWNLOAD_PROTEIN" == "1" ]]; then
   FILE_EXTENSION="protein.faa.gz"
+fi
+
+if [[ "$DATABASE" == *".txt" ]] ; then
+  DOMAINS="."
 fi
 
 for DOMAIN in $DOMAINS; do
@@ -476,18 +483,23 @@ for DOMAIN in $DOMAINS; do
 
     FULL_ASSEMBLY_SUMMARY_FILE="$LIBDIR/$DOMAIN/assembly_summary.txt"
     ASSEMBLY_SUMMARY_FILE="$LIBDIR/$DOMAIN/assembly_summary_filtered.txt"
-
-    echo "Downloading https://ftp.ncbi.nlm.nih.gov/genomes/$DATABASE/$DOMAIN/assembly_summary.txt ..." >&2
-    if [ $DL_MODE = "rsync" ]; then
+  
+    if [[ "$DATABASE" != *".txt" ]] ; then
+      echo "Downloading https://ftp.ncbi.nlm.nih.gov/genomes/$DATABASE/$DOMAIN/assembly_summary.txt ..." >&2
+      if [ $DL_MODE = "rsync" ]; then
         $DL_CMD rsync://ftp.ncbi.nlm.nih.gov/genomes/$DATABASE/$DOMAIN/assembly_summary.txt "$FULL_ASSEMBLY_SUMMARY_FILE" || {
-            c_echo "rsync Download failed! Have a look at valid domains at https://ftp.ncbi.nlm.nih.gov/genomes/$DATABASE ." >&2
-            exit 1;
+          c_echo "rsync Download failed! Have a look at valid domains at https://ftp.ncbi.nlm.nih.gov/genomes/$DATABASE ." >&2
+                  exit 1;
         }
     else
-        $DL_CMD "$FULL_ASSEMBLY_SUMMARY_FILE" https://ftp.ncbi.nlm.nih.gov/genomes/$DATABASE/$DOMAIN/assembly_summary.txt > /dev/null || {
-            c_echo "Download failed! Have a look at valid domains at https://ftp.ncbi.nlm.nih.gov/genomes/$DATABASE ." >&2
-            exit 1;
-        }
+      $DL_CMD "$FULL_ASSEMBLY_SUMMARY_FILE" https://ftp.ncbi.nlm.nih.gov/genomes/$DATABASE/$DOMAIN/assembly_summary.txt > /dev/null || {
+        c_echo "Download failed! Have a look at valid domains at https://ftp.ncbi.nlm.nih.gov/genomes/$DATABASE ." >&2
+              exit 1;
+      }
+      fi
+    else
+      echo "Using custom assembly_summary.txt file at $DATABASE" >&2
+      cp "$DATABASE" "$FULL_ASSEMBLY_SUMMARY_FILE"
     fi
 
     awk -F "\t" "BEGIN {OFS=\"\t\"} $AWK_QUERY" "$FULL_ASSEMBLY_SUMMARY_FILE" > "$ASSEMBLY_SUMMARY_FILE"

--- a/defs.h
+++ b/defs.h
@@ -5,7 +5,7 @@
 
 //#define DEBUG
 
-#define CENTRIFUGER_VERSION "1.1.3-r330"
+#define CENTRIFUGER_VERSION "1.1.3-r331"
 
 #define SAMPLE_SHEET_SEPARATOR_READ_ID "__centrifuger_sample_sheet_separator__"
 

--- a/defs.h
+++ b/defs.h
@@ -5,7 +5,7 @@
 
 //#define DEBUG
 
-#define CENTRIFUGER_VERSION "1.1.2-r329"
+#define CENTRIFUGER_VERSION "1.1.3-r330"
 
 #define SAMPLE_SHEET_SEPARATOR_READ_ID "__centrifuger_sample_sheet_separator__"
 


### PR DESCRIPTION
- Also add a padding in taxonomy tree structure