### PR TITLE
Fix #103 integer overflow in hit score calculation for long matches

### DIFF
--- a/Classifier.hpp
+++ b/Classifier.hpp
@@ -236,7 +236,11 @@ private:
   {
     if (l < _param.minHitLen)
       return 0 ;
-    return (l - _scoreHitLenAdjust) * (l - _scoreHitLenAdjust) ;
+    int64_t adjustedHitLen = (int64_t)l - _scoreHitLenAdjust ;
+    if (adjustedHitLen <= 0)
+      return 0 ;
+    size_t scoreBase = (size_t)adjustedHitLen ;
+    return scoreBase * scoreBase ;
   }
 
   // one hit


### PR DESCRIPTION
## Fixes #103 integer overflow in hit score calculation for long matches

### Summary

This PR fixes an integer overflow in `CalculateHitScore()` for long exact/high-confidence matches in long sequences.

Previously, hit scores were computed as:

```cpp
(l - _scoreHitLenAdjust) * (l - _scoreHitLenAdjust)
```

Since both operands are `int`, the multiplication can overflow signed 32-bit arithmetic before the result is converted to `size_t`. For long sequences or long contigs/scaffolds, this can produce near-`2^64` scores in the classification output for long matches against a reference sequence.

### Observed example

For one real scaffold classification:

```text
readID       scaffold_808625720
hitLength    51021
queryLength  51027
```

The expected score is:

```text
(51021 - 15)^2 = 2601612036
```

But the emitted pre-patch score was:

```text
18446744072016196356
```

This corresponds exactly to the signed 32-bit overflowed result converted to an unsigned 64-bit value.

### Fix

The patch casts to `int64_t` before subtracting and multiplying, guards against non-positive adjusted hit lengths, and converts to `size_t` for the final score:

```cpp
int64_t adjustedHitLen = (int64_t)l - _scoreHitLenAdjust ;
if (adjustedHitLen <= 0)
  return 0 ;
size_t scoreBase = (size_t)adjustedHitLen ;
return scoreBase * scoreBase ;
```

### Testing/Validation

I validated the patch by rebuilding Centrifuger and regenerating the affected output file.

Results:

- The rebuilt Centrifuger completed successfully.
- Headers were identical between pre-patch and patched outputs.
- Both outputs had exactly `10,776,886` data rows.
- The read/scaffold ID sets were identical.
- Only two rows changed globally, exactly the two rows with overflowing scores.
- The main affected row changed from:

```text
18446744072016196356
```

to the expected value:

```text
2601612036
```

- No row remained with `score >= 2^63`.
- No row remained with `score > (queryLength - 15)^2`.
