### PR TITLE
Add the filtered core_nt index from LLNL

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Here is a list of pre-built indexes:
 |  cfr_gtdb_r232 | [GTDB r232](https://gtdb.ecogenomic.org/) | [Dropbox](https://www.dropbox.com/scl/fo/wilot7fzf8bzyfsco81wi/AFzwZhSgE9N1r7uai8DeUec?rlkey=yazr6e4b71pxbz4o4bu7dqft5&st=ekr030j8&dl=0) | 230G | 2026/05/15 |
 |  cfr_gtdb_r232+refseq_hvfpc | GTDB r232 + Refseq human, virus, fungi, protozoa, and contaminant (UniVec,EmVec)| [Dropbox](https://www.dropbox.com/scl/fo/6sf1k7iwnckdca2opl1ir/AK8X0gPn90TF7Ox0XxK8kjI?rlkey=y7787xqylcfssvwjn1w66rmqz&st=ck0sa631&dl=0) | 232G | 2026/05/15 |
 | cfr_core_nt | NCBI core nt | [Dropbox](https://www.dropbox.com/scl/fo/f1mbf7nf893pisoruanb4/AHS06LaJr9EN0Pg7hbifWn8?rlkey=7fgtj6pi53l2iwrjw1k6xq8o8&st=yn57lnkh&dl=0)  | 212G | 2025/06/11 |
+| cfr_llnl_core_nt_202603 | LLNL-curated NCBI core_nt (PMID:40111052) | [Dropbox](https://www.dropbox.com/scl/fo/zkjoh4luk5e3kvzs9hvir/APWYWaOHu-7RVxELTi41_rI?rlkey=soavq4el3od1nch7op99n5mz5&st=o1ckosy7&dl=0) | 242G | 2026/03/01 |
+|  cfr_llnl_core_nt_wseqid_202512 | LLNL-curated NCBI core_nt with sequence ID info but less synchronized taxdmp | [Dropbox](https://www.dropbox.com/scl/fo/zkjoh4luk5e3kvzs9hvir/APWYWaOHu-7RVxELTi41_rI?rlkey=soavq4el3od1nch7op99n5mz5&st=o1ckosy7&dl=0) | 301G | 2025/12/01 |
 
 (You can use the command "./centrifuger-download [Title]" to download the corresponding pre-built index. For the files on the Dropbox, you can right-click and "copy link" for each individual file and use "wget" on that link to download the file through the command line. Other old indexes are available at [Dropbox](https://www.dropbox.com/scl/fo/08horwj8mdzarlk2ocyky/AJIUqBg4ZU4qXdaTBnl64xM?rlkey=y7vk78c3o1pd2fq20f258vuyf&st=57xyuyjl&dl=0))
 

--- a/centrifuger-download
+++ b/centrifuger-download
@@ -374,6 +374,20 @@ if [[ "$DATABASE" == "cfr"* ]] ; then
         "https://www.dropbox.com/scl/fi/mdvdgkojqvvkuw21omq3k/cfr_core_nt.4.cfr?rlkey=vf5km6mmvcgljd8ndopxhmv7f&st=rugp4fcu&dl=1"
       )
       ;;
+    cfr_llnl_core_nt_202603)
+      LINK_LIST=("https://www.dropbox.com/scl/fi/ub8s1x450pdokdlpt2kwu/cfr_llnl_core_nt_202603.1.cfr?rlkey=gare0xz1rxwmofacg9vig6o5m&st=3dji3923&dl=0", \
+        "https://www.dropbox.com/scl/fi/hpmmeysr8rd1sow7xxh6q/cfr_llnl_core_nt_202603.2.cfr?rlkey=iqadmgb4bgsmb4tj23pdmachu&st=xfyjusq1&dl=0", \
+        "https://www.dropbox.com/scl/fi/spuo7htsptzs0wyc69080/cfr_llnl_core_nt_202603.3.cfr?rlkey=5qkm3jqddx1hiw2lanqwfr0vm&st=7tae9ius&dl=0", \
+        "https://www.dropbox.com/scl/fi/rmj4loo8ruwmdl6z0aovy/cfr_llnl_core_nt_202603.4.cfr?rlkey=amo7ujfbjohmycg6inhgcs59q&st=ikelzekk&dl=0"
+        )
+        ;;
+    cfr_llnl_core_nt_wseqid_202512)
+      LINK_LIST=("https://www.dropbox.com/scl/fi/b6chnv80xp3ykm0pwtt7c/cfr_llnl_core_nt_wseqid_202512.1.cfr?rlkey=wt53oh7l4qsqs7e0hwodrnsfk&st=waq8eu4x&dl=0", \
+        "https://www.dropbox.com/scl/fi/4wtmzmtbl6y1qf4htpnu1/cfr_llnl_core_nt_wseqid_202512.2.cfr?rlkey=aq72znrcmab4gir45kpziygl6&st=6ifmhiqg&dl=0", \
+        "https://www.dropbox.com/scl/fi/lbdjrt6fwbnstp3cju4dd/cfr_llnl_core_nt_wseqid_202512.3.cfr?rlkey=zjzic4y7625f1tzzvs5hopq4i&st=oce4z3y7&dl=0", \
+        "https://www.dropbox.com/scl/fi/kd13j3mpglb67044ajhug/cfr_llnl_core_nt_wseqid_202512.4.cfr?rlkey=t5r7za9jech3du6c9rg4hsvqc&st=elvbe43e&dl=0"
+        )
+        ;;
     cfr_gtdb_r232)
       LINK_LIST=("https://www.dropbox.com/scl/fi/4hchiyep1xcq0x10ddaua/cfr_gtdb_r232.1.cfr?rlkey=097skn90om46ie4av8m1grsmo&st=zm6mcmds&dl=1", \
         "https://www.dropbox.com/scl/fi/meb2d46821ctbqs24aps7/cfr_gtdb_r232.2.cfr?rlkey=z1kx2u04hxgtvmixrze78bjim&st=ek18ggav&dl=1", \

--- a/centrifuger-download
+++ b/centrifuger-download
@@ -375,17 +375,17 @@ if [[ "$DATABASE" == "cfr"* ]] ; then
       )
       ;;
     cfr_llnl_core_nt_202603)
-      LINK_LIST=("https://www.dropbox.com/scl/fi/ub8s1x450pdokdlpt2kwu/cfr_llnl_core_nt_202603.1.cfr?rlkey=gare0xz1rxwmofacg9vig6o5m&st=3dji3923&dl=0", \
-        "https://www.dropbox.com/scl/fi/hpmmeysr8rd1sow7xxh6q/cfr_llnl_core_nt_202603.2.cfr?rlkey=iqadmgb4bgsmb4tj23pdmachu&st=xfyjusq1&dl=0", \
-        "https://www.dropbox.com/scl/fi/spuo7htsptzs0wyc69080/cfr_llnl_core_nt_202603.3.cfr?rlkey=5qkm3jqddx1hiw2lanqwfr0vm&st=7tae9ius&dl=0", \
-        "https://www.dropbox.com/scl/fi/rmj4loo8ruwmdl6z0aovy/cfr_llnl_core_nt_202603.4.cfr?rlkey=amo7ujfbjohmycg6inhgcs59q&st=ikelzekk&dl=0"
+      LINK_LIST=("https://www.dropbox.com/scl/fi/ub8s1x450pdokdlpt2kwu/cfr_llnl_core_nt_202603.1.cfr?rlkey=gare0xz1rxwmofacg9vig6o5m&st=3dji3923&dl=1", \
+        "https://www.dropbox.com/scl/fi/hpmmeysr8rd1sow7xxh6q/cfr_llnl_core_nt_202603.2.cfr?rlkey=iqadmgb4bgsmb4tj23pdmachu&st=xfyjusq1&dl=1", \
+        "https://www.dropbox.com/scl/fi/spuo7htsptzs0wyc69080/cfr_llnl_core_nt_202603.3.cfr?rlkey=5qkm3jqddx1hiw2lanqwfr0vm&st=7tae9ius&dl=1", \
+        "https://www.dropbox.com/scl/fi/rmj4loo8ruwmdl6z0aovy/cfr_llnl_core_nt_202603.4.cfr?rlkey=amo7ujfbjohmycg6inhgcs59q&st=ikelzekk&dl=1"
         )
         ;;
     cfr_llnl_core_nt_wseqid_202512)
-      LINK_LIST=("https://www.dropbox.com/scl/fi/b6chnv80xp3ykm0pwtt7c/cfr_llnl_core_nt_wseqid_202512.1.cfr?rlkey=wt53oh7l4qsqs7e0hwodrnsfk&st=waq8eu4x&dl=0", \
-        "https://www.dropbox.com/scl/fi/4wtmzmtbl6y1qf4htpnu1/cfr_llnl_core_nt_wseqid_202512.2.cfr?rlkey=aq72znrcmab4gir45kpziygl6&st=6ifmhiqg&dl=0", \
-        "https://www.dropbox.com/scl/fi/lbdjrt6fwbnstp3cju4dd/cfr_llnl_core_nt_wseqid_202512.3.cfr?rlkey=zjzic4y7625f1tzzvs5hopq4i&st=oce4z3y7&dl=0", \
-        "https://www.dropbox.com/scl/fi/kd13j3mpglb67044ajhug/cfr_llnl_core_nt_wseqid_202512.4.cfr?rlkey=t5r7za9jech3du6c9rg4hsvqc&st=elvbe43e&dl=0"
+      LINK_LIST=("https://www.dropbox.com/scl/fi/b6chnv80xp3ykm0pwtt7c/cfr_llnl_core_nt_wseqid_202512.1.cfr?rlkey=wt53oh7l4qsqs7e0hwodrnsfk&st=waq8eu4x&dl=1", \
+        "https://www.dropbox.com/scl/fi/4wtmzmtbl6y1qf4htpnu1/cfr_llnl_core_nt_wseqid_202512.2.cfr?rlkey=aq72znrcmab4gir45kpziygl6&st=6ifmhiqg&dl=1", \
+        "https://www.dropbox.com/scl/fi/lbdjrt6fwbnstp3cju4dd/cfr_llnl_core_nt_wseqid_202512.3.cfr?rlkey=zjzic4y7625f1tzzvs5hopq4i&st=oce4z3y7&dl=1", \
+        "https://www.dropbox.com/scl/fi/kd13j3mpglb67044ajhug/cfr_llnl_core_nt_wseqid_202512.4.cfr?rlkey=t5r7za9jech3du6c9rg4hsvqc&st=elvbe43e&dl=1"
         )
         ;;
     cfr_gtdb_r232)

--- a/defs.h
+++ b/defs.h
@@ -5,7 +5,7 @@
 
 //#define DEBUG
 
-#define CENTRIFUGER_VERSION "1.1.3-r331"
+#define CENTRIFUGER_VERSION "1.1.3-r332"
 
 #define SAMPLE_SHEET_SEPARATOR_READ_ID "__centrifuger_sample_sheet_separator__"
 


### PR DESCRIPTION
- Add the links to the filtered core_nt database generated by @khyox, as described in  https://journals.asm.org/doi/full/10.1128/msystems.01239-24 